### PR TITLE
Update srst2.py

### DIFF
--- a/scripts/srst2.py
+++ b/scripts/srst2.py
@@ -646,7 +646,7 @@ def get_allele_name_from_db(allele,unique_allele_symbols,unique_cluster_symbols,
 			annotation = ""
 	
 		if not unique_allele_symbols:	
-			allele_name += "_" + seq_id
+			allele_name += "_" + seqid
 		
 		if not unique_allele_symbols:	
 			gene_name += "_" + cluster_id


### PR DESCRIPTION
Correct typo in seqid at line 649 (currently seq_id, which is invalid)

I ran into this error exclusively when trying to use a gene database derived from the VFDB files as described on the website. There is a typo on line 649 where the variable seqid is mistyped as "seq_id". it causes the following failure:

foo@computer2:SRST2$ srst2 --input_se foostaph.fastq.gz --output SA_test --log --gene_db Staphylococcus_VF_clustered.fasta
65260 reads; of these:
65260 (100.00%) were unpaired; of these:
61910 (94.87%) aligned 0 times
21 (0.03%) aligned exactly 1 time
3329 (5.10%) aligned >1 times
5.13% overall alignment rate
[samopen] SAM header is present: 1178 sequences.
[mpileup] 1 samples in 1 input files
Set max per-file depth to 8000
Traceback (most recent call last):
File "/usr/local/bin/srst2", line 9, in
load_entry_point('srst2==0.1.2', 'console_scripts', 'srst2')()
File "/usr/local/lib/python2.7/dist-packages/srst2-0.1.2-py2.7.egg/srst2/srst2.py", line 1316, in main
db_reports, db_results = run_srst2(args,fileSets,args.gene_db,"genes")
File "/usr/local/lib/python2.7/dist-packages/srst2-0.1.2-py2.7.egg/srst2/srst2.py", line 937, in run_srst2
db_reports, db_results_list = process_fasta_db(args, fileSets, run_type, db_reports, db_results_list, fasta)
File "/usr/local/lib/python2.7/dist-packages/srst2-0.1.2-py2.7.egg/srst2/srst2.py", line 991, in process_fasta_db
unique_gene_symbols, unique_allele_symbols,run_type,ST_db,results,gene_list,db_report)
File "/usr/local/lib/python2.7/dist-packages/srst2-0.1.2-py2.7.egg/srst2/srst2.py", line 1101, in map_fileSet_to_db
unique_gene_symbols, unique_allele_symbols)
File "/usr/local/lib/python2.7/dist-packages/srst2-0.1.2-py2.7.egg/srst2/srst2.py", line 679, in parse_scores
gene_name = get_allele_name_from_db(allele,unique_allele_symbols,unique_cluster_symbols,run_type,args)[0]
File "/usr/local/lib/python2.7/dist-packages/srst2-0.1.2-py2.7.egg/srst2/srst2.py", line 649, in get_allele_name_from_db
allele_name += "" + seqid
NameError: global name 'seq_id' is not defined

Does not appear to affect the function of SRST2 with the supplied resistance.fasta database or MLST functions. Correcting the spelling of the variable at line 649 to "seqid" corrects the problem.
