### PR TITLE
Fix for issue 25

### DIFF
--- a/database_clustering/VFDB_cdhit_to_csv.py
+++ b/database_clustering/VFDB_cdhit_to_csv.py
@@ -56,7 +56,8 @@ def main():
 			allele = id_bits[1]+"_"+id_bits[2] # fliL_VP2243
 		else:
 			allele = id_bits[1]
-		clusterid = seq2cluster[seqID]
+		if seqID in seq2cluster:
+			clusterid = seq2cluster[seqID]
 		outstring = ",".join([seqID, clusterid, gene, allele, str(record.seq), re.sub(",","",record.description)]) + "\n"
 		outfile.write(outstring)
 	outfile.close()


### PR DESCRIPTION
This fixes KeyErrors that occur when a given seqID is not found in the seq2cluster dictionary, which tends to happen when the FASTA file contains empty entries that only have a header and no sequence