### PR TITLE
Discrepancy between the wget commands and the srst2 command line.

### DIFF
--- a/README.md
+++ b/README.md
@@ -875,7 +875,7 @@ wget ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR178/ERR178148/ERR178148_2.fastq.gz
 wget ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR178/ERR178156/ERR178156_1.fastq.gz
 wget ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR178/ERR178156/ERR178156_2.fastq.gz
 
-srst2 --input_pe ERR178148*.fastq.gz ERR178156*.fastq.gz  --output serotypes --log --gene_db EcOH.fasta
+srst2 --input_pe ERR178148*.fastq.gz ERR178156*.fastq.gz --output serotypes --log --gene_db EcOH.fasta
 ```
 
 Results will be output in: `[prefix]__genes__EcOH__results.txt`

--- a/README.md
+++ b/README.md
@@ -875,7 +875,7 @@ wget ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR178/ERR178148/ERR178148_2.fastq.gz
 wget ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR178/ERR178156/ERR178156_1.fastq.gz
 wget ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR178/ERR178156/ERR178156_2.fastq.gz
 
-srst2 --input_pe ERR178156*.fastq.gz ERR124656*.fastq.gz --output serotypes --log --gene_db EcOH.fasta
+srst2 --input_pe ERR178148*.fastq.gz ERR178156*.fastq.gz  --output serotypes --log --gene_db EcOH.fasta
 ```
 
 Results will be output in: `[prefix]__genes__EcOH__results.txt`


### PR DESCRIPTION
Fixed a discrepancy between the wget commands and the srst2 command line in the readme.

I also get a different output from the example, but I did not want to include that in the readme because I'm not sure how relevant the difference is.

```
$ cat serotypes__genes__EcOH__results.txt
Sample	fliC	wzm	wzt	wzx	wzy
ERR178148	fliC-H31_30*	-	-	wzx-O131_152*	wzy-O131_354
ERR178156	fliC-H33_32	wzm-O9_89*	wzt-O9_103*	wzx-Onovel22_575*	wzy-Onovel22_574*
```