### PR TITLE
Proposal for compatibility with Biopython 1.78

### DIFF
--- a/database_clustering/VFDBgenus.py
+++ b/database_clustering/VFDBgenus.py
@@ -9,7 +9,6 @@ from argparse import ArgumentParser
 from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-from Bio.Alphabet import IUPAC
 
 def parse_args():
 	parser = ArgumentParser(description='Extract virulence genes by genus from the VFDB database available at http://www.mgc.ac.cn/VFs/Down/CP_VFs.ffn.gz')

--- a/database_clustering/csv_to_gene_db.py
+++ b/database_clustering/csv_to_gene_db.py
@@ -15,7 +15,6 @@ from optparse import OptionParser
 from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-from Bio.Alphabet import IUPAC
 
 def main():
 
@@ -72,8 +71,7 @@ if __name__ == "__main__":
 
 			if seqid_col:
 				seq = fields.pop(seqid_col-1)
-				record = SeqRecord(Seq(seq,
-					   IUPAC.unambiguous_dna),
+				record = SeqRecord(Seq(seq),
 					   id=db_id, 
 					   description=db_id)
 			elif seqs_file_col:

--- a/database_clustering/csv_to_gene_db.py
+++ b/database_clustering/csv_to_gene_db.py
@@ -15,6 +15,11 @@ from optparse import OptionParser
 from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
+try:
+	from Bio.Alphabet.IUPAC import unambiguous_dna
+except ImportError:
+	# Biopython 1.78 has no Bio.Alphabet anymore
+	unambiguous_dna = None
 
 def main():
 
@@ -71,9 +76,20 @@ if __name__ == "__main__":
 
 			if seqid_col:
 				seq = fields.pop(seqid_col-1)
-				record = SeqRecord(Seq(seq),
-					   id=db_id, 
-					   description=db_id)
+				if unambiguous_dna:
+					record = SeqRecord(
+						Seq(seq),
+						id=db_id,
+						description=db_id,
+						alphabet=unambiguous_dna
+					)
+				else:
+					record = SeqRecord(
+						Seq(seq),
+						id=db_id,
+						description=db_id
+					)
+
 			elif seqs_file_col:
 				seqs_file_id = fields.pop(seqs_file_col-1)
 				if seqs_file_id in input_seqs:
@@ -96,5 +112,3 @@ if __name__ == "__main__":
 			
 	f.close()
 	o.close()
-	
-	

--- a/scripts/consensus_alignment.py
+++ b/scripts/consensus_alignment.py
@@ -11,7 +11,6 @@ from argparse import (ArgumentParser, FileType)
 from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-from Bio.Alphabet import IUPAC
 
 def parse_args():
 	"Parse the input arguments, use '-h' for help."


### PR DESCRIPTION
Greetings,

Biopython 1.78 deprecated and removed the Bio.Alphabet module.  I followed their recommendations on how to move forward, published on https://biopython.org/wiki/Alphabet and came up with this small change, so that srst2 can be compatible with this Biopython version as well.

Have a nice day,  :)
Étienne.